### PR TITLE
ETSWORK-9574 - Content in ./.github/ is required to be reviewed by @Workgrid/tech-leads

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @Workgrid/team-next
 
-./github/ @Workgrid/tech-leads
+./.github/ @Workgrid/tech-leads
 
 # We're required to document our development process and therefore want to ensure Tech Leads approve of the change
 README.md @Workgrid/tech-leads


### PR DESCRIPTION
A mistake had been previously made where the `.` after the forward slash was omitted and the proper reviews were not triggered.